### PR TITLE
Expose PerTurbo options to pipeline and fix defaults

### DIFF
--- a/bin/perturbo_inference.py
+++ b/bin/perturbo_inference.py
@@ -5,14 +5,33 @@ import mudata as md
 import numpy as np
 import pandas as pd
 
-def run_perturbo(mdata_input_fp, mdata_output_fp):
 
+def run_perturbo(
+    mdata_input_fp,
+    mdata_output_fp,
+    fit_guide_efficacy=True,  # whether to fit guide efficacy (if false, overrides efficiency_mode)
+    efficiency_mode="mixture",  # can be "mixture" (for low MOI) or "scaled" (low or high MOI)
+    accelerator="gpu",  # can be "auto", "gpu" or "cpu"
+    batch_size=512,  # batch size for training
+    early_stopping=True,  # whether to use early stopping
+    early_stopping_patience=5,  # patience for early stopping
+    lr=0.01,  # learning rate for training
+    num_epochs=100,  # (max) number of epochs for training
+):
     mdata = md.read(mdata_input_fp)
     mdata["gene"].obs = (
-        mdata.obs.join(mdata["gene"].obs.drop(columns=mdata.obs.columns, errors='ignore'))
-        .join(mdata["guide"].obs.drop(columns=mdata.obs.columns.union(mdata["gene"].obs.columns), errors='ignore'))
+        mdata.obs.join(
+            mdata["gene"].obs.drop(columns=mdata.obs.columns, errors="ignore")
+        )
+        .join(
+            mdata["guide"].obs.drop(
+                columns=mdata.obs.columns.union(mdata["gene"].obs.columns),
+                errors="ignore",
+            )
+        )
         .assign(log1p_total_guide_umis=lambda x: np.log1p(x["total_guide_umis"]))
     )
+
     mdata["guide"].X = mdata["guide"].layers["guide_assignment"]
     pairs_to_test_df = pd.DataFrame(mdata.uns["pairs_to_test"])
     mdata.uns["intended_target_names"] = sorted(
@@ -22,14 +41,15 @@ def run_perturbo(mdata_input_fp, mdata_output_fp):
     aggregated_df = (
         pairs_to_test_df.assign(value=1)
         .groupby(["gene_id", "intended_target_name"])
-        .agg(value=('value', 'max')) 
+        .agg(value=("value", "max"))
         .reset_index()
     )
 
     # pivot the data
     mdata["gene"].varm["intended_targets"] = (
-        aggregated_df
-        .pivot(index="gene_id", columns="intended_target_name", values="value")
+        aggregated_df.pivot(
+            index="gene_id", columns="intended_target_name", values="value"
+        )
         .reindex(mdata["gene"].var_names)
         .fillna(0)
     )
@@ -51,32 +71,48 @@ def run_perturbo(mdata_input_fp, mdata_output_fp):
     tested_guides = pairs_to_test_df["guide_id"].unique()
     tested_genes = pairs_to_test_df["gene_id"].unique()
 
-    rna_subset = mdata["gene"][:,tested_genes]
-    grna_feature_ids = mdata["guide"].var['guide_id'].isin(tested_guides)
-    grna_subset = mdata["guide"][:,grna_feature_ids]
+    rna_subset = mdata["gene"][:, tested_genes]
+    grna_feature_ids = mdata["guide"].var["guide_id"].isin(tested_guides)
+    grna_subset = mdata["guide"][:, grna_feature_ids]
 
     mdata_dict = {"gene": rna_subset, "guide": grna_subset}
-    if "hashing" in mdata.mod.keys(): mdata_dict["hashing"] = mdata["hashing"]
+    if "hashing" in mdata.mod.keys():
+        mdata_dict["hashing"] = mdata["hashing"]
     mdata_subset = md.MuData(mdata_dict)
 
     mdata_subset = mdata_subset.copy()
     ########################################
-    
-    perturbo.PERTURBO.setup_mudata(
-            mdata_subset,
-            batch_key="batch",
-            library_size_key="total_gene_umis",
-            continuous_covariates_keys=["total_guide_umis"],
-            guide_by_element_key="intended_targets",
-            gene_by_element_key="intended_targets",
-            modalities={
-                "rna_layer": "gene",
-                "perturbation_layer": "guide",
-            },
-        )
 
-    model = perturbo.PERTURBO(mdata_subset, likelihood="nb")
-    model.train(20, lr=0.01, batch_size=128, accelerator="gpu")
+    perturbo.PERTURBO.setup_mudata(
+        mdata_subset,
+        batch_key="batch",
+        library_size_key="total_gene_umis",
+        continuous_covariates_keys=["log1p_total_guide_umis"],
+        guide_by_element_key="intended_targets",
+        gene_by_element_key="intended_targets",
+        modalities={
+            "rna_layer": "gene",
+            "perturbation_layer": "guide",
+        },
+    )
+
+    model = perturbo.PERTURBO(
+        mdata_subset,
+        likelihood="nb",
+        efficiency_mode=efficiency_mode,
+    )
+
+    model.train(
+        num_epochs=num_epochs,
+        lr=lr,
+        batch_size=batch_size,
+        accelerator=accelerator,
+        early_stopping=early_stopping,
+        early_stopping_patience=early_stopping_patience,
+        fit_guide_efficacy=fit_guide_efficacy,
+        early_stopping_min_delta=1e-5,
+        early_stopping_monitor="elbo_train",
+    )
 
     igvf_name_map = {
         "element": "intended_target_name",
@@ -94,27 +130,92 @@ def run_perturbo(mdata_input_fp, mdata_output_fp):
     mdata = md.read(mdata_input_fp)
     mdata.uns["test_results"] = element_effects[
         [
-            "gene_id", 
+            "gene_id",
             "guide_id",
             "intended_target_name",
             "log2_fc",
             "p_value",
-            "pair_type"
+            "pair_type",
         ]
-            ]
+    ]
 
-    mdata.uns['test_results'].rename(columns={'log2_fc': 'perturbo_log2_fc', 'p_value': 'perturbo_p_value'}, inplace=True)
-    
+    mdata.uns["test_results"].rename(
+        columns={"log2_fc": "perturbo_log2_fc", "p_value": "perturbo_p_value"},
+        inplace=True,
+    )
+
     mdata.write(mdata_output_fp)
     return mdata
+
 
 def main():
     parser = argparse.ArgumentParser(description="Run PerTurbo analysis on MuData")
     parser.add_argument("mdata_input_fp", type=str, help="Input file path for MuData")
     parser.add_argument("mdata_output_fp", type=str, help="Output file path for MuData")
+    parser.add_argument(
+        "--fit_guide_efficacy",
+        action="store_true",
+        help="Whether to fit guide efficacy (overrides efficiency_mode if false)",
+    )
+    parser.add_argument(
+        "--efficiency_mode",
+        type=str,
+        choices=["mixture", "scaled"],
+        default="scaled",
+        help="Efficiency mode for the model (default: scaled)",
+    )
+
+    parser.add_argument(
+        "--accelerator",
+        type=str,
+        choices=["auto", "gpu", "cpu"],
+        default="gpu",
+        help="Accelerator to use for training (default: gpu)",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=512,
+        help="Batch size for training (default: 512)",
+    )
+    parser.add_argument(
+        "--early_stopping",
+        action="store_true",
+        help="Whether to use early stopping during training",
+    )
+    parser.add_argument(
+        "--early_stopping_patience",
+        type=int,
+        default=5,
+        help="Patience for early stopping (default: 5)",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=0.01,
+        help="Learning rate for training (default: 0.01)",
+    )
+    parser.add_argument(
+        "--num_epochs",
+        type=int,
+        default=100,
+        help="Maximum number of epochs for training (default: 100)",
+    )
 
     args = parser.parse_args()
-    run_perturbo(args.mdata_input_fp, args.mdata_output_fp)
+    run_perturbo(
+        args.mdata_input_fp,
+        args.mdata_output_fp,
+        fit_guide_efficacy=args.fit_guide_efficacy,
+        efficiency_mode=args.efficiency_mode,
+        accelerator=args.accelerator,
+        batch_size=args.batch_size,
+        early_stopping=args.early_stopping,
+        early_stopping_patience=args.early_stopping_patience,
+        lr=args.lr,
+        num_epochs=args.num_epochs,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/bin/perturbo_inference.py
+++ b/bin/perturbo_inference.py
@@ -10,7 +10,7 @@ def run_perturbo(
     mdata_input_fp,
     mdata_output_fp,
     fit_guide_efficacy=True,  # whether to fit guide efficacy (if false, overrides efficiency_mode)
-    efficiency_mode="mixture",  # can be "mixture" (for low MOI) or "scaled" (low or high MOI)
+    efficiency_mode="scaled",  # can be "mixture" (for low MOI) or "scaled" (low or high MOI)
     accelerator="gpu",  # can be "auto", "gpu" or "cpu"
     batch_size=512,  # batch size for training
     early_stopping=True,  # whether to use early stopping


### PR DESCRIPTION
I've exposed the following options in perturbo_inference.py

```
fit_guide_efficacy=True,  # whether to fit guide efficacy (if false, overrides efficiency_mode)
efficiency_mode="scaled",  # can be "mixture" (for low MOI) or "scaled" (low or high MOI)
accelerator="gpu",  # can be "auto", "gpu" or "cpu"
batch_size=512,  # batch size for training
early_stopping=True,  # whether to use early stopping
early_stopping_patience=5,  # patience for early stopping
lr=0.01,  # learning rate for training
num_epochs=100,  # (max) number of epochs for training
```

Note that now early stopping is the default behavior and the max number of epochs is set higher. Additionally, I've increased the batch size to what I've been using in the analyses for the manuscript. Finally, I updated the default continuous covariates used during inference to be `continuous_covariates_keys=["log1p_total_guide_umis"]` to match what I've been using.

These options should work fairly well for all datasets. If we want to support `efficiency_mode="mixture"` for low-MOI data Cas9 or base editor screens that would also be reasonable, but I'm not sure exactly how to pull that from the configuration.