### PR TITLE
Correct missing capture_method argument for CLEANSER

### DIFF
--- a/modules/local/guide_assignment_cleanser/main.nf
+++ b/modules/local/guide_assignment_cleanser/main.nf
@@ -5,6 +5,7 @@ process guide_assignment_cleanser {
     input:
         path mudata_input
         val threshold
+        val capture_method
 
     output:
         path "${mudata_input.simpleName}_output.h5mu", emit: guide_assignment_mudata_output
@@ -15,6 +16,6 @@ process guide_assignment_cleanser {
         export CMDSTAN=/root/.cmdstan/cmdstan-2.36.0
         export PATH=\$PATH:\$CMDSTAN/bin
 
-        cleanser -i ${mudata_input} --posteriors-output ${mudata_input.simpleName}_output.h5mu --modality guide --capture-method capture_method --output-layer guide_assignment ${thresh_opt}
+        cleanser -i ${mudata_input} --posteriors-output ${mudata_input.simpleName}_output.h5mu --modality guide --${capture_method} --output-layer guide_assignment ${thresh_opt}
         """
 }

--- a/subworkflows/local/process_mudata_pipeline/main.nf
+++ b/subworkflows/local/process_mudata_pipeline/main.nf
@@ -62,7 +62,7 @@ workflow process_mudata_pipeline {
     Prepare_assignment = prepare_assignment{MuData_Doublets.mudata_doublet}
 
     if (params.GUIDE_ASSIGNMENT_method == "cleanser") {
-        Guide_Assignment = guide_assignment_cleanser(Prepare_assignment.prepare_assignment_mudata.flatten(), params.GUIDE_ASSIGNMENT_cleanser_probability_threshold)
+        Guide_Assignment = guide_assignment_cleanser(Prepare_assignment.prepare_assignment_mudata.flatten(), params.GUIDE_ASSIGNMENT_cleanser_probability_threshold, params.GUIDE_ASSIGNMENT_capture_method)
         guide_assignment_collected =  Guide_Assignment.guide_assignment_mudata_output.collect()
         Mudata_concat = mudata_concat(guide_assignment_collected)
         }

--- a/subworkflows/local/process_mudata_pipeline_HASHING/main.nf
+++ b/subworkflows/local/process_mudata_pipeline_HASHING/main.nf
@@ -81,7 +81,7 @@ workflow process_mudata_pipeline_HASHING {
     Prepare_assignment = prepare_assignment{MuData.mudata}
 
     if (params.GUIDE_ASSIGNMENT_method == "cleanser") {
-        Guide_Assignment = guide_assignment_cleanser(Prepare_assignment.prepare_assignment_mudata.flatten(), params.GUIDE_ASSIGNMENT_cleanser_probability_threshold)
+        Guide_Assignment = guide_assignment_cleanser(Prepare_assignment.prepare_assignment_mudata.flatten(), params.GUIDE_ASSIGNMENT_cleanser_probability_threshold, params.GUIDE_ASSIGNMENT_capture_method)
         guide_assignment_collected =  Guide_Assignment.guide_assignment_mudata_output.collect()
         Mudata_concat = mudata_concat(guide_assignment_collected)
         }


### PR DESCRIPTION
Fix the issue reported here #16. The configuration parameter `GUIDE_ASSIGNMENT_capture_method` should be either `direct-capture` or `crop-seq` for the pipeline to work properly. Introduced here the minimal set of changes for that to work.  