### PR TITLE
Add per-guide analysis with SCEPTRE

### DIFF
--- a/bin/inference_sceptre.R
+++ b/bin/inference_sceptre.R
@@ -1,5 +1,21 @@
 #!/usr/bin/env Rscript
 
+# Declare known globals used in dplyr pipelines to avoid R CMD check notes
+if (getRversion() >= "2.15.1") {
+  utils::globalVariables(
+    c(
+      "grna_id",
+      "guide_id",
+      "response_id",
+      "grna_target",
+      "p_value",
+      "log_2_fold_change",
+      "gene_id",
+      "intended_target_name",
+      "log2_fc"
+    )
+  )
+}
 convert_mudata_to_sceptre_object_v1 <- function(mudata, remove_collinear_covariates = FALSE) {
   # extract information from MuData
   moi <- MultiAssayExperiment::metadata(mudata[["guide"]])$moi
@@ -99,15 +115,14 @@ inference_sceptre_m <- function(mudata, ...) {
       dplyr::filter(grna_target != "non-targeting")
   }
 
-  # assemble arguments to set_analysis_parameters()
+  # assemble base arguments to set_analysis_parameters()
   args_list <- list(...)
 
   if ("discovery_pairs" %in% names(args_list)) {
     warning("The `discovery_pairs` argument is ignored. The `discovery_pairs` are set from the `pairs_to_test` metadata.")
   }
+  # always use discovery pairs from metadata
   args_list[["discovery_pairs"]] <- discovery_pairs
-  args_list$sceptre_object <- sceptre_object
-
   # construct formula excluding gRNA covariates to avoid multicollinearity
   # (gRNA assignments are binary, making grna_n_nonzero and grna_n_umis identical)
   formula_object <- sceptre:::auto_construct_formula_object(
@@ -116,10 +131,20 @@ inference_sceptre_m <- function(mudata, ...) {
   )
   args_list[["formula_object"]] <- formula_object
 
-  # set analysis parameters with custom formula
-  sceptre_object <- do.call(sceptre::set_analysis_parameters, args_list)
+  # We'll run two analyses on the same sceptre_object to exploit caching:
+  # 1) union (grouped / per-element)
+  # 2) singleton (per-guide)
 
-  # extract gRNA assignment and turn off QC
+  # Prepare a copy of the sceptre_object reference for chaining
+  args_list$sceptre_object <- sceptre_object
+
+  ## 1) Union / grouped (per-element) analysis
+  args_union <- args_list
+  args_union$grna_integration_strategy <- "union"
+  # set analysis parameters for union
+  sceptre_object <- do.call(sceptre::set_analysis_parameters, args_union)
+
+  # assign grnas and run QC (relaxed thresholds to keep all cells; mirror prior behaviour)
   sceptre_object <- sceptre_object |>
     sceptre::assign_grnas(method = "thresholding", threshold = 1) |>
     sceptre::run_qc(
@@ -128,12 +153,12 @@ inference_sceptre_m <- function(mudata, ...) {
       p_mito_threshold = 1
     )
 
-  # run discovery analysis
+  # run discovery analysis (grouped)
   sceptre_object <- sceptre_object |>
     sceptre::run_discovery_analysis()
 
-  # get results
-  discovery_results <- sceptre_object |>
+  # get union (per-element) results
+  union_results <- sceptre_object |>
     sceptre::get_result(analysis = "run_discovery_analysis") |>
     dplyr::select(response_id, grna_target, p_value, log_2_fold_change) |>
     dplyr::rename(
@@ -141,18 +166,71 @@ inference_sceptre_m <- function(mudata, ...) {
       intended_target_name = grna_target,
       log2_fc = log_2_fold_change
     )
+  # use union_results directly (no extra distinct/left_join)
+  union_test_results <- union_results
 
-  discovery_unique <- discovery_results |>
-    dplyr::distinct(gene_id, intended_target_name, .keep_all = TRUE)
+  # store union results in mudata metadata as requested
+  MultiAssayExperiment::metadata(mudata)$test_results <- union_test_results
 
-  # add results to MuData
-  test_results <- pairs_to_test |>
-    dplyr::left_join(discovery_unique, by = c("intended_target_name", "gene_id"))
+  # also write the per-element (union) results to file
+  try(
+    write.table(
+      union_test_results,
+      file = "per_element_output.tsv",
+      sep = "\t",
+      row.names = FALSE,
+      quote = FALSE
+    ),
+    silent = TRUE
+  )
 
-  MultiAssayExperiment::metadata(mudata)$test_results <- test_results
+  ## 2) Singleton (per-guide) analysis — reuse sceptre_object to exploit caching
+  args_singleton <- args_list
+  args_singleton$grna_integration_strategy <- "singleton"
+  # set analysis parameters for singleton (reuse same sceptre_object reference)
+  sceptre_object <- do.call(sceptre::set_analysis_parameters, args_singleton)
 
-  # return
-  return(list(mudata = mudata, test_results = test_results))
+  # run assignment, qc and discovery for singleton
+  sceptre_object <- sceptre_object |>
+    sceptre::assign_grnas(method = "thresholding", threshold = 1) |>
+    sceptre::run_qc(
+      n_nonzero_trt_thresh = 0L,
+      n_nonzero_cntrl_thresh = 0L,
+      p_mito_threshold = 1
+    ) |>
+    sceptre::run_discovery_analysis()
+
+  # extract singleton (per-guide) results, preserve grna_id and rename to guide_id
+  singleton_results <- sceptre_object |>
+    sceptre::get_result(analysis = "run_discovery_analysis") |>
+    dplyr::select(response_id, grna_id, grna_target, p_value, log_2_fold_change) |>
+    dplyr::rename(
+      gene_id = response_id,
+      guide_id = grna_id,
+      intended_target_name = grna_target,
+      log2_fc = log_2_fold_change
+    )
+
+  # use singleton_results directly
+  singleton_test_results <- singleton_results
+
+  try(
+    write.table(
+      singleton_test_results,
+      file = "per_guide_output.tsv",
+      sep = "\t",
+      row.names = FALSE,
+      quote = FALSE
+    ),
+    silent = TRUE
+  )
+
+  # return mudata (with union results in metadata) and both result tables
+  return(list(
+    mudata = mudata,
+    union_test_results = union_test_results,
+    singleton_test_results = singleton_test_results
+  ))
 }
 
 ### Run Command (only execute when script is run directly, not when sourced)
@@ -180,9 +258,14 @@ if (!exists(".sourced_from_test")) {
     control_group = control_group,
     resampling_mechanism = resampling_mechanism
   )
+  # write outputs: per-element (union) and per-guide (singleton)
+  if (!is.null(results$union_test_results)) {
+    try(write.table(results$union_test_results, file = "per_element_output.tsv", sep = "\t", row.names = FALSE, quote = FALSE), silent = TRUE)
+  }
+  if (!is.null(results$singleton_test_results)) {
+    try(write.table(results$singleton_test_results, file = "per_guide_output.tsv", sep = "\t", row.names = FALSE, quote = FALSE), silent = TRUE)
+  }
 
-  # write MuData
-  write.csv(results$test_results, file = "test_results.csv", row.names = FALSE)
-  # MuData::writeH5MU(object = results$mudata, file = 'inference_mudata.h5mu')
+  # write the modified MuData (contains union results in metadata as 'test_results')
+  try(MuData::writeH5MU(object = results$mudata, file = "inference_mudata.h5mu"), silent = TRUE)
 }
- 

--- a/bin/perturbo_inference.py
+++ b/bin/perturbo_inference.py
@@ -75,7 +75,9 @@ def run_perturbo(
         intended_targets_df = intended_targets_df.drop(control_elements, axis=1)
 
         # filter any cells with >1 guide
-        multi_guide_cells = mdata[guide_modality_name].X.sum(axis=1) > 1
+        multi_guide_cells = (
+            mdata[guide_modality_name].layers["guide_assignment"].sum(axis=1) > 1
+        )
         if multi_guide_cells.any():
             print(
                 f"Removing {multi_guide_cells.sum()} cells with multiple guides. ({multi_guide_cells.sum() / len(mdata) * 100:.1f}% of total)"

--- a/bin/perturbo_inference.py
+++ b/bin/perturbo_inference.py
@@ -90,7 +90,7 @@ def run_perturbo(
             print(
                 f"Removing {multi_guide_cells.sum()} cells with multiple guides. ({multi_guide_cells.sum() / len(mdata) * 100:.1f}% of total)"
             )
-            mdata = mdata[multi_guide_cells, :].copy()
+            mdata = mdata[~multi_guide_cells, :].copy()
 
     mdata[guide_modality_name].varm["intended_targets"] = intended_targets_df
     mdata.uns[element_key] = intended_targets_df.columns.tolist()

--- a/bin/perturbo_inference.py
+++ b/bin/perturbo_inference.py
@@ -228,7 +228,7 @@ def run_perturbo(
 
     # Write results table to TSV (required)
     print("Writing results to ", results_tsv_fp)
-    mdata.uns["test_results"].to_tsv(results_tsv_fp, index=False, sep="\t")
+    mdata.uns["test_results"].to_csv(results_tsv_fp, index=False, sep="\t")
 
     # Optionally write the full MuData if an output path was provided
     if mdata_output_fp:

--- a/bin/perturbo_inference_chunked.py
+++ b/bin/perturbo_inference_chunked.py
@@ -56,9 +56,9 @@ def run_perturbo_chunked(
 
     print(f"Starting chunked PerTurbo inference on {mdata_input_fp}...")
     mdata = md.read_h5mu(mdata_input_fp, backed="r")
-    if mdata[gene_modality_name].n_vars < chunk_size:
+    if mdata[gene_modality_name].n_vars <= chunk_size:
         print(
-            "Number of genes is less than chunk size; running standard PerTurbo inference instead."
+            "Number of genes is less than or equal to chunk size; running standard PerTurbo inference instead."
         )
         perturbo_script = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "perturbo_inference.py"

--- a/modules/local/inference_perturbo/main.nf
+++ b/modules/local/inference_perturbo/main.nf
@@ -15,7 +15,7 @@ process inference_perturbo {
 
     script:
         """
-        perturbo_inference.py ${mudata} per_element_output.tsv --mudata_output_fp inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --inference_type element
+        perturbo_inference.py ${mudata} per_element_output.tsv --mdata_output_fp inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --inference_type element
         perturbo_inference.py ${mudata} per_guide_output.tsv --efficiency_mode ${efficiency_mode} --inference_type guide
         """
 }

--- a/modules/local/inference_perturbo/main.nf
+++ b/modules/local/inference_perturbo/main.nf
@@ -15,7 +15,7 @@ process inference_perturbo {
 
     script:
         """
-        perturbo_inference.py ${mudata} inference_mudata.h5mu --efficiency_mode ${efficiency_mode}
-        export_output_single.py --mudata inference_mudata.h5mu --inference_method ${inference_method}
+        perturbo_inference.py ${mudata} per_element_output.tsv --mudata_output_fp inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --inference_type element
+        perturbo_inference.py ${mudata} per_guide_output.tsv --efficiency_mode ${efficiency_mode} --inference_type guide
         """
 }

--- a/modules/local/inference_perturbo_trans/main.nf
+++ b/modules/local/inference_perturbo_trans/main.nf
@@ -16,7 +16,7 @@ process inference_perturbo_trans {
 
     script:
         """
-        perturbo_inference.py ${mudata} per_element_output.tsv --test_all_pairs --mudata_output_fp inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --inference_type element
+        perturbo_inference.py ${mudata} per_element_output.tsv --test_all_pairs --mdata_output_fp inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --inference_type element
         perturbo_inference.py ${mudata} per_guide_output.tsv --test_all_pairs --efficiency_mode ${efficiency_mode} --inference_type guide
         """
 }

--- a/modules/local/inference_perturbo_trans/main.nf
+++ b/modules/local/inference_perturbo_trans/main.nf
@@ -16,7 +16,7 @@ process inference_perturbo_trans {
 
     script:
         """
-        perturbo_inference_chunked.py ${mudata} inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --test_all_pairs --chunk_size 8000
+        perturbo_inference_chunked.py ${mudata} inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --test_all_pairs --chunk_size 8192
         export_output_single.py --mudata inference_mudata.h5mu --inference_method ${inference_method}
         """
 }

--- a/modules/local/inference_perturbo_trans/main.nf
+++ b/modules/local/inference_perturbo_trans/main.nf
@@ -16,7 +16,7 @@ process inference_perturbo_trans {
 
     script:
         """
-        perturbo_inference_chunked.py ${mudata} inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --test_all_pairs --chunk_size 8192
-        export_output_single.py --mudata inference_mudata.h5mu --inference_method ${inference_method}
+        perturbo_inference.py ${mudata} per_element_output.tsv --test_all_pairs --mudata_output_fp inference_mudata.h5mu --efficiency_mode ${efficiency_mode} --inference_type element
+        perturbo_inference.py ${mudata} per_guide_output.tsv --test_all_pairs --efficiency_mode ${efficiency_mode} --inference_type guide
         """
 }

--- a/modules/local/inference_sceptre/main.nf
+++ b/modules/local/inference_sceptre/main.nf
@@ -5,7 +5,9 @@ process inference_sceptre {
     path mudata_fp
 
     output:
-    path "test_results.csv", emit: test_results
+    path "inference_mudata.h5mu", emit: inference_mudata
+    path "per_element_output.tsv", emit: per_element_output
+    path "per_guide_output.tsv", emit: per_guide_output
 
     script:
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -201,7 +201,7 @@ process {
         }
     }
 
-    withName: 'inference_perturbo' {
+    withName: 'inference_perturbo|inference_perturbo_trans' {
         container = params.containers.perturbo
         // GPU processes
         cpus = { Math.min(4 * task.attempt, 48) }

--- a/subworkflows/local/process_mudata_pipeline/main.nf
+++ b/subworkflows/local/process_mudata_pipeline/main.nf
@@ -14,7 +14,7 @@ include { prepare_all_guide_inference } from '../../../modules/local/prepare_all
 include { prepare_user_guide_inference } from '../../../modules/local/prepare_user_guide_inference'
 include { inference_sceptre } from '../../../modules/local/inference_sceptre'
 include { inference_perturbo } from '../../../modules/local/inference_perturbo'
-include { inference_perturbo as inference_perturbo_trans } from '../../../modules/local/inference_perturbo'
+include { inference_perturbo_trans } from '../../../modules/local/inference_perturbo_trans'
 include { inference_mudata } from '../../../modules/local/inference_mudata'
 include { mergedResults } from '../../../modules/local/mergedResults'
 include { publishFiles } from '../../../modules/local/publishFiles'
@@ -95,10 +95,10 @@ workflow process_mudata_pipeline {
             GTF_Reference.gencode_gtf,
             params.INFERENCE_max_target_distance_bp
         )
-        PrepareInference_trans = prepare_all_guide_inference(
-            Mudata_concat.concat_mudata,
-            GTF_Reference.gencode_gtf
-        )
+        // PrepareInference_trans = prepare_all_guide_inference(
+        //     Mudata_concat.concat_mudata,
+        //     GTF_Reference.gencode_gtf
+        // )
     }
 
     if (params.INFERENCE_method == "sceptre"){
@@ -122,7 +122,7 @@ workflow process_mudata_pipeline {
         PerturboResults_cis = inference_perturbo(PrepareInference_cis.mudata_inference_input, "perturbo", params.Multiplicity_of_infection)
         GuideInference_cis = mergedResults(SceptreResults_cis.test_results, PerturboResults_cis.inference_mudata)
         // Process trans results
-        GuideInference_trans = inference_perturbo_trans(PrepareInference_trans.mudata_inference_input, "perturbo", params.Multiplicity_of_infection)
+        GuideInference_trans = inference_perturbo_trans(Mudata_concat.concat_mudata, "perturbo", params.Multiplicity_of_infection)
 
         // Rename tsv outputs to avoid conflicts
         cis_per_element = GuideInference_cis.per_element_output.map { file -> file.copyTo(file.parent.resolve("cis-${file.name}")) }

--- a/subworkflows/local/process_mudata_pipeline/main.nf
+++ b/subworkflows/local/process_mudata_pipeline/main.nf
@@ -95,10 +95,10 @@ workflow process_mudata_pipeline {
             GTF_Reference.gencode_gtf,
             params.INFERENCE_max_target_distance_bp
         )
-        // PrepareInference_trans = prepare_all_guide_inference(
-        //     Mudata_concat.concat_mudata,
-        //     GTF_Reference.gencode_gtf
-        // )
+        PrepareInference_trans = prepare_all_guide_inference(
+            Mudata_concat.concat_mudata,
+            GTF_Reference.gencode_gtf
+        )
     }
 
     if (params.INFERENCE_method == "sceptre"){
@@ -122,7 +122,7 @@ workflow process_mudata_pipeline {
         PerturboResults_cis = inference_perturbo(PrepareInference_cis.mudata_inference_input, "perturbo", params.Multiplicity_of_infection)
         GuideInference_cis = mergedResults(SceptreResults_cis.test_results, PerturboResults_cis.inference_mudata)
         // Process trans results
-        GuideInference_trans = inference_perturbo_trans(Mudata_concat.concat_mudata, "perturbo", params.Multiplicity_of_infection)
+        GuideInference_trans = inference_perturbo_trans(PrepareInference_trans.mudata_inference_input, "perturbo", params.Multiplicity_of_infection)
 
         // Rename tsv outputs to avoid conflicts
         cis_per_element = GuideInference_cis.per_element_output.map { file -> file.copyTo(file.parent.resolve("cis-${file.name}")) }


### PR DESCRIPTION
Draft proposal to have SCEPTRE match the new PerTurbo behavior where it always runs the per-guide analysis and per-element analysis, and outputs three files for backwards compatibility
- an updated mudata with the test results (currently just for the per-element analysis with the assumption that we will collect all the results from inference into a final mudata in a different step, although this behavior can be changed)
- a per_guide_results.tsv file from the results with `grna_integration_strategy="singleton"`
- a per_element_results.tsv file from the results with `grna_integration_strategy="union"`

Currently only the module file changes to inference_sceptre.R are implemented since this change would break the downstream parts of the pipeline that expect only one "test_results.csv" file out of SCEPTRE. If this strategy looks promising @LucasSilvaFerreira I can move forward with integrating into the pipeline