### PR TITLE
Add subsample subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.0dev - 2026-April-29
+
+### `Added`
+
+- Added FASTQ subsampling parameters: `subsample_seed`, `subsample_probability`, and `subsample_record_count`.
+- Added `conf/modules/subsample.config` to configure `FQ_SUBSAMPLE` arguments, output prefix, and publish directory.
+- Added local `FASTQ_SUBSAMPLE` subworkflow wrapping the nf-core `fq/subsample` module and emitting subsampled reads plus module versions.
+
 ## v1.0.0 - 2025-AUG-19
 
 - Initial release of IGVF Perturb-seq Pipeline

--- a/conf/modules/subsample.config
+++ b/conf/modules/subsample.config
@@ -1,0 +1,15 @@
+process {
+    withName: 'FQ_SUBSAMPLE' {
+        ext.args = {
+            params.subsample_probability != null
+                ? "-s ${params.subsample_seed} -p ${params.subsample_probability}"
+                : "-s ${params.subsample_seed} -n ${params.subsample_record_count}"
+        }
+        ext.prefix = { "${meta.id}.subsample" }
+        publishDir = [
+            path: { "${params.outdir}/subsample" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,6 +66,11 @@ params {
     js = "assets/js"
     svg = "assets/svg"
 
+    // FASTQ subsampling parameters
+    subsample_seed         = 13
+    subsample_probability  = 0.1
+    subsample_record_count = 1000
+
     // Per-process resource limits
     max_cpus = 32      // TO-DO, YOU set this limit
     max_memory = 256.GB  // TO-DO, YOU set this limit

--- a/nextflow.config
+++ b/nextflow.config
@@ -191,6 +191,7 @@ profiles {
 }
 
 includeConfig 'conf/modules.config'
+includeConfig 'conf/modules/subsample.config'
 
 manifest {
     name            = 'pinellolab/CRISPR_Pipeline'

--- a/subworkflows/local/fastq_subsample/main.nf
+++ b/subworkflows/local/fastq_subsample/main.nf
@@ -2,25 +2,18 @@ include { FQ_SUBSAMPLE } from '../../../modules/nf-core/fq/subsample'
 
 workflow FASTQ_SUBSAMPLE {
     take:
-    ch_inputs
+    ch_fq_input
 
     main:
-
-    ch_fq_input = ch_inputs
-        .map { meta, r1_path, r2_path ->
-            def reads = [r1_path, r2_path]
-            [meta, reads]
-        }
 
     FQ_SUBSAMPLE(ch_fq_input)
 
     ch_subsampled = FQ_SUBSAMPLE.out.fastq
         .map { meta, files ->
-            def r1_path = files instanceof List ? files[0] : files
-            def r2_path = files instanceof List && files.size() > 1 ? files[1] : null
-            [meta, r1_path, r2_path]
+            def fastqs = files instanceof List ? files : [files]
+            [meta, fastqs]
         }
 
     emit:
-    reads    = ch_subsampled
+    subsample    = ch_subsampled
 }

--- a/subworkflows/local/fastq_subsample/main.nf
+++ b/subworkflows/local/fastq_subsample/main.nf
@@ -1,0 +1,26 @@
+include { FQ_SUBSAMPLE } from '../../../modules/nf-core/fq/subsample'
+
+workflow FASTQ_SUBSAMPLE {
+    take:
+    ch_inputs
+
+    main:
+
+    ch_fq_input = ch_inputs
+        .map { meta, r1_path, r2_path ->
+            def reads = [r1_path, r2_path]
+            [meta, reads]
+        }
+
+    FQ_SUBSAMPLE(ch_fq_input)
+
+    ch_subsampled = FQ_SUBSAMPLE.out.fastq
+        .map { meta, files ->
+            def r1_path = files instanceof List ? files[0] : files
+            def r2_path = files instanceof List && files.size() > 1 ? files[1] : null
+            [meta, r1_path, r2_path]
+        }
+
+    emit:
+    reads    = ch_subsampled
+}


### PR DESCRIPTION
Add subsample subworkflow and related parameters and module config. 

- Added FASTQ subsampling parameters: `subsample_seed`, `subsample_probability`, and `subsample_record_count`.
- Added `conf/modules/subsample.config` to configure `FQ_SUBSAMPLE` arguments, output prefix, and publish directory.
- Added local `FASTQ_SUBSAMPLE` subworkflow wrapping the nf-core `fq/subsample` module and emitting subsampled reads plus module versions.