### PR TITLE
add 3pv3 special case to mappingHashing, mirroring mappingGuide

### DIFF
--- a/modules/local/mappingHashing/main.nf
+++ b/modules/local/mappingHashing/main.nf
@@ -11,6 +11,7 @@ process mappingHashing {
     path t2g_hashing
     path parsed_seqSpec_file
     path barcode_file
+    val is_10xv3v
 
     output:
     path "*_ks_hashing_out", emit: ks_hashing_out_dir
@@ -20,12 +21,21 @@ process mappingHashing {
         def batch = meta.measurement_sets
         def fastq_files = reads.join(' ')
         """
+        set -euo pipefail
         echo "Processing $batch with $fastq_files"
 
-        chemistry=\$(extract_parsed_seqspec.py --file ${parsed_seqSpec_file})
+        if [ "${is_10xv3v}" == "true" ]; then
+            CHEM="10XV3"
+            WORKFLOW="kite:10xFB"
+        else
+            CHEM=\$(extract_parsed_seqspec.py --file ${parsed_seqSpec_file})
+            WORKFLOW="kite"
+        fi
+
+        echo "Final Chemistry: \$CHEM"
 
         kb count -i ${hashing_index} -g ${t2g_hashing} --verbose -w ${barcode_file} \\
-                --h5ad -x \$chemistry -o ${batch}_ks_hashing_out -t ${task.cpus} \\
+                --workflow \$WORKFLOW --h5ad -x \$CHEM -o ${batch}_ks_hashing_out -t ${task.cpus} \\
                 ${fastq_files} --overwrite
 
         echo "Hash KB mapping Complete"

--- a/subworkflows/local/mapping_hashing_pipeline/main.nf
+++ b/subworkflows/local/mapping_hashing_pipeline/main.nf
@@ -28,7 +28,8 @@ workflow mapping_hashing_pipeline {
         HashingRef.hashing_index,
         HashingRef.t2g_hashing,
         SeqSpecResult.parsed_seqspec,
-        SeqSpecResult.barcode_file
+        SeqSpecResult.barcode_file,
+        params.is_10x3v3
     )
 
     ks_hashing_out_dir_collected = MappingOut.ks_hashing_out_dir


### PR DESCRIPTION
When params.is_10x3v3 is true, force CHEM="10XV3" and --workflow kite:10xFB so HTO barcodes are corrected against the 10x v3 whitelist and match the RNA barcode space downstream.

Addresses #77 