### PR TITLE
Add alternative inference workflow entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Update the pipeline-specific parameters in the `params` section, for example:
     GUIDE_ASSIGNMENT_SCEPTRE_n_em_rep = 5
 
     INFERENCE_method = 'default' // sceptre or perturbo. Default will run sceptre and perturbo in cis and perturbo in trans (for elements and per guide)
+    INFERENCE_input_mudata = null // required only for -entry INFERENCE_FROM_MUDATA
     INFERENCE_target_guide_pairing_strategy = 'default'
     INFERENCE_PERTURBO_BATCH_SIZE = 4096 // Batch size passed to PerTurbo training in both cis and trans runs
     INFERENCE_PERTURBO_TRANS_MAX_GENES_PER_CHUNK = 8000 // For trans PerTurbo only; values <= 0 disable chunking and values > 0 cap each balanced gene chunk
@@ -127,6 +128,26 @@ Update the pipeline-specific parameters in the `params` section, for example:
     NETWORK_custom_central_nodes = 'undefined'
     NETWORK_central_nodes_num = 1
 ```
+
+### Run default inference from an existing MuData
+
+Use this mode when you already have a post-guide-assignment MuData file (for example, after custom cell/guide filtering) and only need to rerun the default inference workflow.
+
+```bash
+nextflow run main.nf \
+  -entry INFERENCE_FROM_MUDATA \
+  -profile local \
+  --INFERENCE_input_mudata /path/to/filtered_input.h5mu \
+  --INFERENCE_method default \
+  --INFERENCE_target_guide_pairing_strategy default \
+  --REFERENCE_gtf_local_path /path/to/gencode_gtf.gtf.gz \
+  --outdir ./outputs_mudata_inference
+```
+
+Notes:
+- This entrypoint runs inference only (no mapping, guide assignment, dashboard, or additional QC workflows).
+- GTF is still required in default mode because the pipeline constructs cis pairs before running inference.
+- If `REFERENCE_gtf_local_path` does not exist, the pipeline uses `REFERENCE_gtf_download_path`.
 
 #### 2. Compute Environment Configuration
 

--- a/main.nf
+++ b/main.nf
@@ -16,8 +16,11 @@
 */
 
 include { CRISPR_PIPELINE }  from './workflows/crispr_pipeline'
+include { inference_pipeline } from './subworkflows/local/inference_pipeline'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_crispr_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_crispr_pipeline'
+include { skipGTFDownload } from './modules/local/skipGTFDownload'
+include { downloadGTF } from './modules/local/downloadGTF'
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NAMED WORKFLOWS FOR PIPELINE
@@ -39,6 +42,46 @@ workflow NFCORE_CRISPR {
     CRISPR_PIPELINE(
         samplesheet
         )
+}
+
+//
+// WORKFLOW: Run default inference starting from an existing MuData file
+//
+workflow INFERENCE_FROM_MUDATA {
+
+    main:
+    if (!params.INFERENCE_input_mudata) {
+        error "INFERENCE_FROM_MUDATA requires --INFERENCE_input_mudata <path_to_h5mu>."
+    }
+    if (params.INFERENCE_method != 'default') {
+        error "INFERENCE_FROM_MUDATA requires --INFERENCE_method 'default'."
+    }
+    if (params.INFERENCE_target_guide_pairing_strategy != 'default') {
+        error "INFERENCE_FROM_MUDATA requires --INFERENCE_target_guide_pairing_strategy 'default'."
+    }
+
+    mudata_input = file(params.INFERENCE_input_mudata)
+    if (!mudata_input.exists()) {
+        error "INFERENCE_input_mudata file was not found: ${params.INFERENCE_input_mudata}"
+    }
+
+    if (file(params.REFERENCE_gtf_local_path).exists()) {
+        GTF_Reference = skipGTFDownload(file(params.REFERENCE_gtf_local_path))
+    }
+    else {
+        if (!params.REFERENCE_gtf_download_path) {
+            error "REFERENCE_gtf_download_path is not set and REFERENCE_gtf_local_path does not exist."
+        }
+        GTF_Reference = downloadGTF(params.REFERENCE_gtf_download_path)
+    }
+
+    Inference = inference_pipeline(
+        mudata_input,
+        GTF_Reference.gencode_gtf
+    )
+
+    emit:
+    inference_mudata = Inference.inference_mudata
 }
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,6 +39,7 @@ params {
     GUIDE_ASSIGNMENT_SCEPTRE_n_em_rep = 5
 
     INFERENCE_method = 'default'
+    INFERENCE_input_mudata = null
     INFERENCE_target_guide_pairing_strategy = 'default'
     INFERENCE_PERTURBO_BATCH_SIZE = 4096
     INFERENCE_PERTURBO_TRANS_MAX_GENES_PER_CHUNK = 8000

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -212,6 +212,15 @@
                     "description": "Inference method to run.",
                     "help_text": "The default mode runs cis SCEPTRE, cis Perturbo, and trans Perturbo using the default guide-target pairing strategy."
                 },
+                "INFERENCE_input_mudata": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "file-path",
+                    "description": "Path to an input MuData file for `-entry INFERENCE_FROM_MUDATA` runs.",
+                    "help_text": "Use this when rerunning default inference from a pre-existing, post-guide-assignment MuData file. GTF annotation is still required in default mode to construct cis pairs."
+                },
                 "INFERENCE_target_guide_pairing_strategy": {
                     "type": "string",
                     "default": "default",


### PR DESCRIPTION
Added an alternative entrypoint for the inference pipeline to allow users to re-run inference after filtering out a subset of guides. Assumes that the provided MuData object has already undergone guide calling.nextflow run.

Currently requires the reference GTF used for cis inference. 

```
main.nf \
  -entry INFERENCE_FROM_MUDATA \
  -profile local \
  --INFERENCE_input_mudata /path/to/filtered_input.h5mu \
  --INFERENCE_method default \
  --INFERENCE_target_guide_pairing_strategy default \
  --REFERENCE_gtf_local_path /path/to/gencode_gtf.gtf.gz \
  --outdir ./outputs_mudata_inference
```

(these options can alternatively be set via a config file)