### PR TITLE
Compute the dashboard's mean guides per cell and cells per guide from the guide_assignment layer

### DIFF
--- a/bin/create_dashboard_df.py
+++ b/bin/create_dashboard_df.py
@@ -18,6 +18,15 @@ def human_format(num):
         num /= 1000.0
     return '{}{}'.format('{:f}'.format(num).rstrip('0').rstrip('.'), ['', 'K', 'M', 'B', 'T'][magnitude])
 
+def guide_assignment_counts(guide_mod, axis):
+    ## axis=1 -> guides assigned per cell, axis=0 -> cells assigned per guide.
+    ## Counts come from the binary guide_assignment layer rather than the raw guide
+    ## UMI counts in .X, and an entry counts as assigned when it is non-zero: the
+    ## same definition used by mapping_guide.py and by the guide histograms in
+    ## create_dashboard_plots.py. Accepts a sparse or dense layer.
+    counts = (guide_mod.layers['guide_assignment'] > 0).sum(axis=axis)
+    return np.asarray(counts).ravel()
+
 def new_block(modality, description, subject, value_display, highlighted=False, table=None, table_description=None, image='', image_description=''):
     if table is None:
         table = pd.DataFrame()
@@ -891,10 +900,10 @@ def create_dashboard_df(guide_fq_tbl, mudata_path, gene_ann_path, filtered_ann_p
 
     ### Create inference visualization df
     ##mean guides/cell
-    guides_per_cell = np.sum(mudata.mod['guide'].X, axis=1)
+    guides_per_cell = guide_assignment_counts(mudata.mod['guide'], axis=1)
     mean_guides_per_cell = np.mean(guides_per_cell)
     ##mean cell/guides
-    cells_per_guide = np.sum(mudata.mod['guide'].X, axis=0)
+    cells_per_guide = guide_assignment_counts(mudata.mod['guide'], axis=0)
     mean_cells_per_guide = np.mean(cells_per_guide)
 
     iv_highlight = f"Mean guides per cell: {human_format(mean_guides_per_cell)}, Mean cells per guide: {human_format(mean_cells_per_guide)}"

--- a/bin/create_dashboard_df_HASHING.py
+++ b/bin/create_dashboard_df_HASHING.py
@@ -20,6 +20,15 @@ def human_format(num):
         num /= 1000.0
     return '{}{}'.format('{:f}'.format(num).rstrip('0').rstrip('.'), ['', 'K', 'M', 'B', 'T'][magnitude])
 
+def guide_assignment_counts(guide_mod, axis):
+    ## axis=1 -> guides assigned per cell, axis=0 -> cells assigned per guide.
+    ## Counts come from the binary guide_assignment layer rather than the raw guide
+    ## UMI counts in .X, and an entry counts as assigned when it is non-zero: the
+    ## same definition used by mapping_guide.py and by the guide histograms in
+    ## create_dashboard_plots_HASHING.py. Accepts a sparse or dense layer.
+    counts = (guide_mod.layers['guide_assignment'] > 0).sum(axis=axis)
+    return np.asarray(counts).ravel()
+
 def new_block(modality, description, subject, value_display, highlighted=False, table=None, table_description=None, image='', image_description=''):
     if table is None:
         table = pd.DataFrame()
@@ -908,10 +917,10 @@ def create_dashboard_df(guide_fq_tbl, hashing_fq_tbl, mudata_path, gene_ann_path
 
     ### Create inference visualization df
     ##mean guides/cell
-    guides_per_cell = np.sum(mudata.mod['guide'].X, axis=1)
+    guides_per_cell = guide_assignment_counts(mudata.mod['guide'], axis=1)
     mean_guides_per_cell = np.mean(guides_per_cell)
     ##mean cell/guides
-    cells_per_guide = np.sum(mudata.mod['guide'].X, axis=0)
+    cells_per_guide = guide_assignment_counts(mudata.mod['guide'], axis=0)
     mean_cells_per_guide = np.mean(cells_per_guide)
 
     iv_highlight = f"Mean guides per cell: {human_format(mean_guides_per_cell)}, Mean cells per guide: {human_format(mean_cells_per_guide)}"

--- a/tests/test_dashboard_guide_stats.py
+++ b/tests/test_dashboard_guide_stats.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""Regression tests for the dashboard guide-assignment summary metrics.
+
+Run with pytest, or standalone with the pipeline's own dependencies:
+
+    python tests/test_dashboard_guide_stats.py
+"""
+
+import os
+import sys
+
+import anndata as ad
+import numpy as np
+from scipy.sparse import csr_matrix
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, 'bin')
+)
+
+from create_dashboard_df import guide_assignment_counts
+from create_dashboard_df_HASHING import (
+    guide_assignment_counts as guide_assignment_counts_hashing,
+)
+
+# Three cells x four guides. The raw guide UMI counts carry background signal on
+# almost every guide, while the assignment matrix keeps one guide for cell 0, two
+# for cell 1 and none for cell 2.
+RAW_GUIDE_UMIS = np.array([
+    [50, 3, 1, 0],
+    [40, 0, 30, 2],
+    [1, 2, 0, 1],
+], dtype=float)
+
+ASSIGNMENT = np.array([
+    [1, 0, 0, 0],
+    [1, 0, 1, 0],
+    [0, 0, 0, 0],
+], dtype=float)
+
+IMPLEMENTATIONS = (guide_assignment_counts, guide_assignment_counts_hashing)
+
+
+def make_guide_mod(assignment, raw_counts=RAW_GUIDE_UMIS, sparse=False):
+    """A guide modality shaped like the one add_guide_assignment.py writes."""
+    guide = ad.AnnData(X=csr_matrix(raw_counts) if sparse else raw_counts.copy())
+    guide.layers['guide_assignment'] = (
+        csr_matrix(assignment) if sparse else assignment.copy()
+    )
+    return guide
+
+
+def test_guides_per_cell_counts_assigned_guides_not_umis():
+    for counts in IMPLEMENTATIONS:
+        for sparse in (False, True):
+            guides_per_cell = counts(make_guide_mod(ASSIGNMENT, sparse=sparse), axis=1)
+            assert list(guides_per_cell) == [1, 2, 0]
+            assert np.mean(guides_per_cell) == 1.0
+            # Summing .X instead would report 42.33 guides per cell.
+            assert np.mean(guides_per_cell) != np.mean(np.sum(RAW_GUIDE_UMIS, axis=1))
+
+
+def test_cells_per_guide_counts_assigned_cells_not_umis():
+    for counts in IMPLEMENTATIONS:
+        for sparse in (False, True):
+            cells_per_guide = counts(make_guide_mod(ASSIGNMENT, sparse=sparse), axis=0)
+            assert list(cells_per_guide) == [2, 0, 1, 0]
+            assert np.mean(cells_per_guide) == 0.75
+            assert np.mean(cells_per_guide) != np.mean(np.sum(RAW_GUIDE_UMIS, axis=0))
+
+
+def test_summary_follows_the_assignment_method():
+    """Two assignment callers over identical raw counts must summarise differently."""
+    permissive = make_guide_mod((RAW_GUIDE_UMIS > 0).astype(float))
+    strict = make_guide_mod((RAW_GUIDE_UMIS >= 30).astype(float))
+    for counts in IMPLEMENTATIONS:
+        assert np.mean(counts(permissive, axis=1)) != np.mean(counts(strict, axis=1))
+        assert np.mean(counts(permissive, axis=0)) != np.mean(counts(strict, axis=0))
+
+
+def test_non_binary_assignment_values_count_once_per_guide():
+    """An assignment layer holding scores rather than 0/1 still counts guides."""
+    for counts in IMPLEMENTATIONS:
+        assert list(counts(make_guide_mod(ASSIGNMENT * 7.0), axis=1)) == [1, 2, 0]
+        assert list(
+            counts(make_guide_mod(ASSIGNMENT * 7.0, sparse=True), axis=0)
+        ) == [2, 0, 1, 0]
+
+
+def test_empty_assignment_layer():
+    empty = np.zeros((3, 4))
+    for counts in IMPLEMENTATIONS:
+        assert list(counts(make_guide_mod(empty), axis=1)) == [0, 0, 0]
+        assert list(counts(make_guide_mod(empty, sparse=True), axis=0)) == [0, 0, 0, 0]
+
+
+if __name__ == '__main__':
+    for name, test in list(globals().items()):
+        if name.startswith('test_') and callable(test):
+            test()
+            print('PASS', name)


### PR DESCRIPTION
This PR proposes computing the dashboard's "Mean guides per cell" and "Mean cells per guide" from the binary `guide_assignment` layer instead of the raw guide UMI counts in `.X`, which is the Inference-tab discrepancy reported in #96. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/237. You can sign in with your GitHub ID to claim ownership of the project.

Fixes #96

## What is wrong

`bin/create_dashboard_df.py` and `bin/create_dashboard_df_HASHING.py` build the Inference tab's two headline figures by summing `mudata.mod['guide'].X`:

```python
guides_per_cell = np.sum(mudata.mod['guide'].X, axis=1)
mean_guides_per_cell = np.mean(guides_per_cell)
cells_per_guide = np.sum(mudata.mod['guide'].X, axis=0)
mean_cells_per_guide = np.mean(cells_per_guide)
```

`.X` holds raw guide UMI counts, so both numbers are UMI totals rather than guide counts, and neither one moves when the guide assignment method changes — which is exactly what @OlgaPushkarev saw when Cleanser and Sceptre runs printed identical values. The histograms produced in the same dashboard run, `plot_guides_per_cell` and `plot_cells_per_guide` in `bin/create_dashboard_plots.py`, already read `layers['guide_assignment']`, so the headline numbers contradict the plots sitting next to them. `bin/mapping_guide.py` documents the same definition the histograms use: `np.sum(guide.layers["guide_assignment"] > 0, axis=...)`.

#96 cites `bin/qc_metrics_json.py:404-405`; that file is not on `main`, but the expression it describes is the one `create_dashboard_df.py` uses today, and it also appears at the corresponding lines of the in-flight branches that introduce that file — so a fix on `main` is where it will carry forward from.

## Reproducing it on main

At `43c89c0` (current `main`), with fixed raw counts and two different assignment callers over them:

```python
import numpy as np, anndata as ad, mudata as md
from scipy.sparse import csr_matrix

rng = np.random.default_rng(0)
counts = rng.poisson(0.8, size=(400, 25)).astype(float)
counts[np.arange(400), rng.integers(0, 25, size=400)] += rng.poisson(60, size=400) + 20

for label, thresh in (("permissive", 5), ("strict", 25)):
    guide = ad.AnnData(X=csr_matrix(counts))
    guide.layers["guide_assignment"] = csr_matrix((counts >= thresh).astype(float))
    g = md.MuData({"guide": guide}).mod["guide"]
    print(label,
          "X ->", round(float(np.mean(np.sum(g.X, axis=1))), 2),
          "| guide_assignment ->", round(float(np.mean(np.sum(g.layers["guide_assignment"], axis=1))), 2))
```

```
permissive X -> 101.08 | guide_assignment -> 1.03
strict     X -> 101.08 | guide_assignment -> 1.0
```

Through `human_format`, `main` renders that as `Mean guides per cell: 101, Mean cells per guide: 1.62K` for both callers — 101 guides per cell drawn from a 25-guide library — while the histograms in the same dashboard show 1.03 guides per cell and 16.5 cells per guide.

## The change

Both dashboard builders gain a `guide_assignment_counts(guide_mod, axis)` helper that counts non-zero entries of the `guide_assignment` layer along the requested axis, and the two means are computed from it. `axis=1` gives guides per cell and `axis=0` cells per guide, matching `mapping_guide.py` and the histograms. It accepts sparse or dense layers, and counts a guide once per cell if an assignment step ever writes scores rather than 0/1.

Nothing else moves: no function signature changes, no new inputs, and the `guide_assignment` layer is already read a few lines above in both files, so the layer was always available at that point.

## How it was verified

- `tests/test_dashboard_guide_stats.py` — five checks across both dashboard variants, covering sparse and dense layers, non-binary assignment values, an empty layer, and the property from #96: two assignment callers over identical raw counts must summarise differently. It runs under pytest or standalone (`python tests/test_dashboard_guide_stats.py`) using dependencies the dashboard step already has.
- The tests are red without the fix: pointing the helper back at `guide_mod.X` fails `test_guides_per_cell_counts_assigned_guides_not_umis` on its first assertion, while the empty-layer control stays green.
- Run before on `main` and after on this branch, with identical results and no new failures: `python -m compileall bin/`, importing all four `create_dashboard_*` modules, `nextflow config -profile test`, and `nextflow run . -profile test -preview -stub`.

## How this was managed

This work was tracked on https://eastagiletracker.com/projects/237/stories/105767, on a board imported from this repository's own issues and pull requests (98 stories, 4 labels) at https://eastagiletracker.com/projects/237.

![board](https://raw.githubusercontent.com/eastagiletracker/CRISPRPipeline/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
